### PR TITLE
プロフィール画面-View-プロフィール編集画面のViewを作成

### DIFF
--- a/lib/ui/profile_god_edit/profile_god_edit_info.dart
+++ b/lib/ui/profile_god_edit/profile_god_edit_info.dart
@@ -4,41 +4,6 @@ class ProfileGodEditInfo extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Column(children: [
-      // Container(
-      //   margin: EdgeInsets.symmetric(
-      //     horizontal: 50.0,
-      //     vertical: 10.0,
-      //   ),
-      //   child: Column(
-      //     crossAxisAlignment: CrossAxisAlignment.start,
-      //     children: [
-      //       Text(
-      //         '表示名',
-      //         style: TextStyle(
-      //           color: const Color(0xFF909090),
-      //           fontWeight: FontWeight.bold,
-      //         ),
-      //       ),
-      //       TextFormField(
-      //         obscureText: false,
-      //         decoration: const InputDecoration(
-      //           hintText: 'マイペースにお腹の空いた神',
-      //           filled: true,
-      //           fillColor: const Color(0xFFE8E8E8),
-      //           border: OutlineInputBorder(
-      //             borderRadius: const BorderRadius.all(
-      //               const Radius.circular(10.0),
-      //             ),
-      //             borderSide: BorderSide.none,
-      //           ),
-      //         ),
-      //         onSaved: (String value) => () {
-      //           print('Value for field saved as "$value"');
-      //         },
-      //       ),
-      //     ],
-      //   ),
-      // ),
       InfoForm(title: '表示名'),
       InfoForm(title: 'ログインID'),
       InfoForm(title: '神さまの名言'),
@@ -93,7 +58,6 @@ class _InfoFormState extends State<InfoForm> {
                 //maxLengthEnforced: false,
                 obscureText: false,
                 maxLines: 1,
-                //パスワード
                 onChanged: _handleText,
                 decoration: const InputDecoration(
                   hintText: '',

--- a/lib/ui/profile_god_edit/profile_god_edit_info.dart
+++ b/lib/ui/profile_god_edit/profile_god_edit_info.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+
+class ProfileGodEditInfo extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Column(children: [
+      // Container(
+      //   margin: EdgeInsets.symmetric(
+      //     horizontal: 50.0,
+      //     vertical: 10.0,
+      //   ),
+      //   child: Column(
+      //     crossAxisAlignment: CrossAxisAlignment.start,
+      //     children: [
+      //       Text(
+      //         '表示名',
+      //         style: TextStyle(
+      //           color: const Color(0xFF909090),
+      //           fontWeight: FontWeight.bold,
+      //         ),
+      //       ),
+      //       TextFormField(
+      //         obscureText: false,
+      //         decoration: const InputDecoration(
+      //           hintText: 'マイペースにお腹の空いた神',
+      //           filled: true,
+      //           fillColor: const Color(0xFFE8E8E8),
+      //           border: OutlineInputBorder(
+      //             borderRadius: const BorderRadius.all(
+      //               const Radius.circular(10.0),
+      //             ),
+      //             borderSide: BorderSide.none,
+      //           ),
+      //         ),
+      //         onSaved: (String value) => () {
+      //           print('Value for field saved as "$value"');
+      //         },
+      //       ),
+      //     ],
+      //   ),
+      // ),
+      InfoForm(title: '表示名'),
+      InfoForm(title: 'ログインID'),
+      InfoForm(title: '神さまの名言'),
+    ]);
+  }
+}
+
+class InfoForm extends StatefulWidget {
+  final String title;
+
+  InfoForm({this.title});
+
+  @override
+  _InfoFormState createState() => _InfoFormState(title: this.title);
+}
+
+class _InfoFormState extends State<InfoForm> {
+  final String title;
+  String _text = '';
+
+  _InfoFormState({this.title});
+
+  void _handleText(String e) {
+    setState(() {
+      _text = e;
+    });
+  }
+
+  Widget build(BuildContext context) {
+    return Container(
+        padding: const EdgeInsets.symmetric(
+          horizontal: 50.0,
+          vertical: 10.0,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              this.title,
+              style: TextStyle(
+                color: const Color(0xFF909090),
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            SizedBox(
+              height: 40.0,
+              width: 200,
+              child: TextField(
+                enabled: true,
+                // 入力数
+                //maxLength: 10,
+                //maxLengthEnforced: false,
+                obscureText: false,
+                maxLines: 1,
+                //パスワード
+                onChanged: _handleText,
+                decoration: const InputDecoration(
+                  hintText: '',
+                  filled: true,
+                  fillColor: const Color(0xFFE8E8E8),
+                  border: OutlineInputBorder(
+                    borderRadius: const BorderRadius.all(
+                      const Radius.circular(10.0),
+                    ),
+                    borderSide: BorderSide.none,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ));
+  }
+}

--- a/lib/ui/profile_god_edit/profile_god_edit_page.dart
+++ b/lib/ui/profile_god_edit/profile_god_edit_page.dart
@@ -6,20 +6,29 @@ import 'package:tapiten_app/ui/profile_god_edit/profile_got_edit_icon.dart';
 class ProfileGodEditPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
+    final bottomSpace = MediaQuery.of(context).viewInsets.bottom;
+
     return MultiProvider(
       providers: [],
       child: MaterialApp(
         title: 'プロフィール',
         home: Scaffold(
+          resizeToAvoidBottomInset: false,
           appBar: AppBar(
             backgroundColor: Colors.white,
             title: ProfileGodEditPageTitle(),
           ),
-          body: Container(
-            child: Column(children: [
-              ProfileGodEditIcon(),
-              ProfileGodEditInfo(),
-            ]),
+          body: SingleChildScrollView(
+            reverse: true,
+            child: Padding(
+              padding: EdgeInsets.only(bottom: bottomSpace),
+              child: Container(
+                child: Column(children: [
+                  ProfileGodEditIcon(),
+                  ProfileGodEditInfo(),
+                ]),
+              ),
+            ),
           ),
         ),
       ),

--- a/lib/ui/profile_god_edit/profile_god_edit_page.dart
+++ b/lib/ui/profile_god_edit/profile_god_edit_page.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:tapiten_app/ui/profile_god_edit/profile_god_edit_info.dart';
+import 'package:tapiten_app/ui/profile_god_edit/profile_got_edit_icon.dart';
+
+class ProfileGodEditPage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MultiProvider(
+      providers: [],
+      child: MaterialApp(
+        title: 'プロフィール',
+        home: Scaffold(
+          appBar: AppBar(
+            backgroundColor: Colors.white,
+            title: ProfileGodEditPageTitle(),
+          ),
+          body: Container(
+            child: Column(children: [
+              ProfileGodEditIcon(),
+              ProfileGodEditInfo(),
+            ]),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class ProfileGodEditPageTitle extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      'プロフィール',
+      style: TextStyle(
+        color: Color(0xFF909090),
+        fontWeight: FontWeight.bold,
+      ),
+    );
+  }
+}

--- a/lib/ui/profile_god_edit/profile_got_edit_icon.dart
+++ b/lib/ui/profile_god_edit/profile_got_edit_icon.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class ProfileGodEditIcon extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.only(top: 60, bottom: 5),
+      child: Center(
+        child: Icon(
+          Icons.account_circle,
+          color: Colors.black,
+          size: 100,
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## 概要
- プロフィール編集画面のViewを作成
- 神さまのみ
- profile_god_editフォルダに作成しました

## イメージ
![スクリーンショット 2020-09-07 1 39 24](https://user-images.githubusercontent.com/38127109/92330588-f98b8b80-f0aa-11ea-9862-6d47189469f1.png)


## 懸念点
- キーボード表示時の画面の上スクロールについてSingleChildScrollViewを使ったが、適切なのか？
参考にした記事：https://yaba-blog.com/flutter-keyboard-form-hidden/

- 神さまの名言の枠のサイズを大きく設定したかったができなかった
