### PR TITLE
Google アカウントでサービスにサインインできるように実装

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -2,6 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<!-- Put me in the [my_project]/ios/Runner/Info.plist file -->
+	<!-- Google Sign-in Section -->
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<!-- TODO Replace this value: -->
+				<!-- Copied from GoogleService-Info.plist key REVERSED_CLIENT_ID -->
+				<string>com.googleusercontent.apps.459118560107-t1b5fj9u6mua667rl4gdgegr6al1qgp7</string>
+			</array>
+		</dict>
+	</array>
+	<!-- End of the Google Sign-in Section -->
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/lib/ui/login/sign_in_with_google.dart
+++ b/lib/ui/login/sign_in_with_google.dart
@@ -34,29 +34,22 @@ class _SiginWithGoogleState extends State<SiginWithGoogle> {
     );
   }
 
-  // ログイン処理
-  Future<FirebaseUser> _handleGoogleSignIn() async {
+  // ログイン成功時にログインユーザを返す
+  Future<User> _handleGoogleSignIn() async {
     GoogleSignInAccount googleUser = await _googleSignIn.signIn();
     GoogleSignInAuthentication googleAuth = await googleUser.authentication;
-    final AuthCredential credential = GoogleAuthProvider.getCredential(
+    final AuthCredential credential = GoogleAuthProvider.credential(
       accessToken: googleAuth.accessToken,
       idToken: googleAuth.idToken,
     );
-    final UserCredential authResult =
-        await _auth.signInWithCredential(credential);
-    final user = authResult.user;
-
-    print("------------------");
-    print(authResult);
-    print("------------------");
+    final User user = (await _auth.signInWithCredential(credential)).user;
 
     return user;
   }
 
   // Google SignIn に成功したら Login ページに飛ぶ
-  void transitionNextPage(FirebaseUser user) {
+  void transitionNextPage(User user) {
     if (user == null) return;
-
     Navigator.push(
         context, MaterialPageRoute(builder: (context) => LoginPage()));
   }

--- a/lib/ui/login/sign_in_with_google.dart
+++ b/lib/ui/login/sign_in_with_google.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:tapiten_app/ui/login/login_page.dart';
+
+class SignInWithGooglePage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    Firebase.initializeApp();
+    return Container(
+      child: Scaffold(
+        appBar: AppBar(title: new Text("Firebase Google ログイン")),
+        body: SiginWithGoogle(),
+      ),
+    );
+  }
+}
+
+class SiginWithGoogle extends StatefulWidget {
+  @override
+  _SiginWithGoogleState createState() => _SiginWithGoogleState();
+}
+
+class _SiginWithGoogleState extends State<SiginWithGoogle> {
+  FirebaseUser _user;
+  final _googleSignIn = new GoogleSignIn();
+  final _auth = FirebaseAuth.instance;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(child: _buildGoogleSignInButton()),
+    );
+  }
+
+  // ログイン処理
+  Future<FirebaseUser> _handleGoogleSignIn() async {
+    GoogleSignInAccount googleUser = await _googleSignIn.signIn();
+    GoogleSignInAuthentication googleAuth = await googleUser.authentication;
+    final AuthCredential credential = GoogleAuthProvider.getCredential(
+      accessToken: googleAuth.accessToken,
+      idToken: googleAuth.idToken,
+    );
+    final UserCredential authResult =
+        await _auth.signInWithCredential(credential);
+    final user = authResult.user;
+
+    print("------------------");
+    print(authResult);
+    print("------------------");
+
+    return user;
+  }
+
+  // Google SignIn に成功したら Login ページに飛ぶ
+  void transitionNextPage(FirebaseUser user) {
+    if (user == null) return;
+
+    Navigator.push(
+        context, MaterialPageRoute(builder: (context) => LoginPage()));
+  }
+
+  // ボタン
+  Widget _buildGoogleSignInButton() {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: <Widget>[
+        Center(
+          child: RaisedButton(
+            child: Text("Google Sign In"),
+            onPressed: () {
+              _handleGoogleSignIn().then((user) {
+                setState(() {
+                  transitionNextPage(user);
+                });
+              }).catchError((error) {
+                print(error);
+              });
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/ui/login/sign_in_with_google.dart
+++ b/lib/ui/login/sign_in_with_google.dart
@@ -1,13 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:google_sign_in/google_sign_in.dart';
-import 'package:firebase_core/firebase_core.dart';
 import 'package:tapiten_app/ui/login/login_page.dart';
 
 class SignInWithGoogleButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    Firebase.initializeApp();
     return Container(
       child: SafeArea(
         child: Column(

--- a/lib/ui/login/sign_in_with_google.dart
+++ b/lib/ui/login/sign_in_with_google.dart
@@ -4,25 +4,32 @@ import 'package:google_sign_in/google_sign_in.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:tapiten_app/ui/login/login_page.dart';
 
-class SignInWithGooglePage extends StatelessWidget {
+class SignInWithGoogleButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     Firebase.initializeApp();
     return Container(
-      child: Scaffold(
-        appBar: AppBar(title: new Text("Firebase Google ログイン")),
-        body: SiginWithGoogle(),
+      child: SafeArea(
+        child: Column(
+          children: [
+            SizedBox(
+                width: 300,
+                height: 50,
+                child: SigninWithGoogle(),
+            )
+          ],
+        ),
       ),
     );
   }
 }
 
-class SiginWithGoogle extends StatefulWidget {
+class SigninWithGoogle extends StatefulWidget {
   @override
-  _SiginWithGoogleState createState() => _SiginWithGoogleState();
+  _SigninWithGoogleState createState() => _SigninWithGoogleState();
 }
 
-class _SiginWithGoogleState extends State<SiginWithGoogle> {
+class _SigninWithGoogleState extends State<SigninWithGoogle> {
   final _googleSignIn = new GoogleSignIn();
   final _auth = FirebaseAuth.instance;
 
@@ -61,7 +68,7 @@ class _SiginWithGoogleState extends State<SiginWithGoogle> {
       children: <Widget>[
         Center(
           child: RaisedButton(
-            child: Text("Google Sign In"),
+            child: Text("Googleではじめる"),
             onPressed: () {
               _handleGoogleSignIn().then((user) {
                 setState(() {

--- a/lib/ui/login/sign_in_with_google.dart
+++ b/lib/ui/login/sign_in_with_google.dart
@@ -23,7 +23,6 @@ class SiginWithGoogle extends StatefulWidget {
 }
 
 class _SiginWithGoogleState extends State<SiginWithGoogle> {
-  FirebaseUser _user;
   final _googleSignIn = new GoogleSignIn();
   final _auth = FirebaseAuth.instance;
 
@@ -50,6 +49,7 @@ class _SiginWithGoogleState extends State<SiginWithGoogle> {
   // Google SignIn に成功したら Login ページに飛ぶ
   void transitionNextPage(User user) {
     if (user == null) return;
+    // NOTE: リダイレクト先の入力項目は要調整
     Navigator.push(
         context, MaterialPageRoute(builder: (context) => LoginPage()));
   }

--- a/lib/ui/top/top_page.dart
+++ b/lib/ui/top/top_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:tapiten_app/ui/top/top_page_icon.dart';
-import 'package:tapiten_app/ui/top/top_page_start_button.dart';
+import 'package:tapiten_app/ui/login/sign_in_with_google.dart';
 
 class TopPage extends StatelessWidget {
   @override
@@ -15,7 +15,7 @@ class TopPage extends StatelessWidget {
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                 children: [
                   TopPageIcon(),
-                  TopPageStartButton(),
+                  SignInWithGoogleButton(),
                 ],
               ),
             ),


### PR DESCRIPTION
## 概要
- サービス立ち上げ時にユーザはまず Google でサインインするので、その部分を実装

## 実装内容
- Google でサインインする
- ボタンはトップページで呼ぶ

## イメージ
- トップ画面から Google サインインのポップアップがでて、認証に成功するとアカウント情報入力のページに飛ばしてます(ここは仮。内容変更の必要がある場合は別 PR で対応します)
- public なリポジトリなので、一部隠してます
![googlesignin](https://user-images.githubusercontent.com/36844012/92331466-c698c600-f0b1-11ea-8398-4629a2488234.gif)


## 懸念点
- まだログインの例外をキャッチしていない
