### PR TITLE
UID のローカル保存・8文字未満のログインIDを弾く validation の追加

### DIFF
--- a/lib/ui/login/login_page.dart
+++ b/lib/ui/login/login_page.dart
@@ -65,16 +65,8 @@ class _LoginInfoFormState extends State<LoginInfoForm> {
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
           ValidateTextInputField(
-            topTitle: '表示名',
-            obscure: false,
-          ),
-          ValidateTextInputField(
             topTitle: 'ログインID',
             obscure: false,
-          ),
-          ValidateTextInputField(
-            topTitle: 'パスワード',
-            obscure: true,
           ),
           Text('新規登録後、プライバシーポリシー及び\n利用規約に同意したものとします。'),
         ],

--- a/lib/ui/login/login_page.dart
+++ b/lib/ui/login/login_page.dart
@@ -38,14 +38,27 @@ class LoginForm extends StatefulWidget {
 }
 
 class _LoginFormState extends State<LoginForm> {
+  final _formKey = GlobalKey<FormState>();
   @override
   Widget build(BuildContext context) {
-    return Container(
+    return Form(
+      key: _formKey,
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: <Widget>[
           LoginInfoForm(),
-          LoginButton(),
+          Container(
+            width: 200,
+            margin: const EdgeInsets.all(0),
+            child: RaisedButton(
+              color: Colors.grey,
+              onPressed: () {
+                _formKey.currentState.validate();
+              },
+              child: Text('作成'),
+              textColor: Colors.white,
+            ),
+          ),
         ],
       ),
     );
@@ -108,6 +121,14 @@ class ValidateTextInputField extends StatelessWidget {
                 borderSide: BorderSide.none,
               ),
             ),
+
+            // MEMO: 今後この画面で入力フォームが増える場合は、それぞれのフォームで validate ロジックが必要
+            // 今は1つなので雛形に直接記述
+            validator: (value) {
+              if (value.length < 8) {
+                return "8文字以上で設定してください";
+              }
+            },
           ),
         ),
         SizedBox(
@@ -118,24 +139,24 @@ class ValidateTextInputField extends StatelessWidget {
   }
 }
 
-class LoginButton extends StatelessWidget {
-  void _onPressed() {
-    print('hello');
-  }
+// class LoginButton extends StatelessWidget {
+//   void _onPressed() {
+//     print('hello');
+//   }
 
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      width: 200,
-      margin: const EdgeInsets.all(0),
-      child: RaisedButton(
-        color: Colors.grey,
-        onPressed: () {
-          _onPressed();
-        },
-        child: Text('作成'),
-        textColor: Colors.white,
-      ),
-    );
-  }
-}
+//   @override
+//   Widget build(BuildContext context) {
+//     return Container(
+//       width: 200,
+//       margin: const EdgeInsets.all(0),
+//       child: RaisedButton(
+//         color: Colors.grey,
+//         onPressed: () {
+//           _onPressed();
+//         },
+//         child: Text('作成'),
+//         textColor: Colors.white,
+//       ),
+//     );
+//   }
+// }

--- a/lib/ui/login/sign_in_with_google.dart
+++ b/lib/ui/login/sign_in_with_google.dart
@@ -2,6 +2,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:tapiten_app/main.dart';
+import 'package:tapiten_app/storage/user_id.dart';
 
 class SignInWithGoogleButton extends StatelessWidget {
   @override
@@ -47,7 +48,7 @@ class _SigninWithGoogleState extends State<SigninWithGoogle> {
       idToken: googleAuth.idToken,
     );
     final User user = (await _auth.signInWithCredential(credential)).user;
-
+    await UserId().saveUserId(id: user.uid);
     return user;
   }
 


### PR DESCRIPTION
#### 解決issue
[#33 ](https://github.com/shun-shun123/tapiten_app/issues/33) に関わるが、差分肥大のため一旦 PR

## 概要
- タイトルの通り

## 実装内容
- Google サインインに成功したときに UID をローカル保存
- ログインID は 8文字以上に限定

## イメージ
![0bd0554643db5e6e544c4212437e980c](https://user-images.githubusercontent.com/36844012/92488684-d804de00-f229-11ea-9d5c-1565f818e8c2.gif)


## 懸念点
- 今後サービスとしてのスケールを考えると、修正すべき点がある(MEMO参照)
