### PR TITLE
ユーザIDとログインIDの組み合わせを Firestore に保存する

### DIFF
--- a/lib/storage/shared_preferences_keys.dart
+++ b/lib/storage/shared_preferences_keys.dart
@@ -1,4 +1,5 @@
 class SharedPreferencesKeys {
   static const String userMode = 'UserMode';
   static const String userId = 'UserId';
+  static const String loginId = 'LoginId';
 }

--- a/lib/storage/user_login_id.dart
+++ b/lib/storage/user_login_id.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tapiten_app/storage/shared_preferences_keys.dart';
+
+class UserLoginId {
+  static String loginId;
+
+  Future saveLoginId({@required String loginid}) async {
+    var sharedPreferences = await SharedPreferences.getInstance();
+    sharedPreferences.setString(SharedPreferencesKeys.loginId, loginid);
+    UserLoginId.loginId = loginid;
+  }
+}

--- a/lib/ui/login/login_page.dart
+++ b/lib/ui/login/login_page.dart
@@ -1,6 +1,11 @@
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:tapiten_app/main.dart';
 import 'package:tapiten_app/ui/login/login_view_model.dart';
+import 'package:tapiten_app/storage/user_id.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:tapiten_app/storage/user_login_id.dart';
 
 class LoginPage extends StatelessWidget {
   @override
@@ -39,6 +44,7 @@ class LoginForm extends StatefulWidget {
 
 class _LoginFormState extends State<LoginForm> {
   final _formKey = GlobalKey<FormState>();
+
   @override
   Widget build(BuildContext context) {
     return Form(
@@ -54,6 +60,9 @@ class _LoginFormState extends State<LoginForm> {
               color: Colors.grey,
               onPressed: () {
                 _formKey.currentState.validate();
+                print('ローカルのUID:${UserId.userId}');
+                print('ログインID: ${UserLoginId.loginId}');
+                // commitToFireStore(loginId);
               },
               child: Text('作成'),
               textColor: Colors.white,
@@ -64,6 +73,16 @@ class _LoginFormState extends State<LoginForm> {
     );
   }
 }
+
+// 初回なので set で保存する
+// void commitToFireStore(String loginId) {
+//   FirebaseFirestore.instance.collection('user_info').doc(UserId.userId).set(
+//     {
+//       'id': UserId.userId,
+//       'loginId': loginId,
+//     },
+//   );
+// }
 
 class LoginInfoForm extends StatefulWidget {
   @override
@@ -91,6 +110,15 @@ class _LoginInfoFormState extends State<LoginInfoForm> {
 class ValidateTextInputField extends StatelessWidget {
   final String topTitle;
   final bool obscure;
+
+  String input = '';
+
+  void _handleText(String e) {
+    input = e;
+    print('入力された値: ${input}');
+    UserLoginId().saveLoginId(loginid: input);
+  }
+
   ValidateTextInputField({this.topTitle, this.obscure});
   @override
   Widget build(BuildContext context) {
@@ -129,6 +157,7 @@ class ValidateTextInputField extends StatelessWidget {
                 return "8文字以上で設定してください";
               }
             },
+            onChanged: _handleText,
           ),
         ),
         SizedBox(

--- a/lib/ui/login/login_page.dart
+++ b/lib/ui/login/login_page.dart
@@ -60,8 +60,6 @@ class _LoginFormState extends State<LoginForm> {
               color: Colors.grey,
               onPressed: () {
                 _formKey.currentState.validate();
-                print('ローカルのUID:${UserId.userId}');
-                print('ログインID: ${UserLoginId.loginId}');
                 commitToFireStore(UserLoginId.loginId);
               },
               child: Text('作成'),
@@ -113,9 +111,7 @@ class ValidateTextInputField extends StatelessWidget {
 
   String input = '';
 
-  void _handleText(String e) {
-    input = e;
-    print('入力された値: ${input}');
+  void _handleText(String input) {
     UserLoginId().saveLoginId(loginid: input);
   }
 

--- a/lib/ui/login/login_page.dart
+++ b/lib/ui/login/login_page.dart
@@ -62,7 +62,7 @@ class _LoginFormState extends State<LoginForm> {
                 _formKey.currentState.validate();
                 print('ローカルのUID:${UserId.userId}');
                 print('ログインID: ${UserLoginId.loginId}');
-                // commitToFireStore(loginId);
+                commitToFireStore(UserLoginId.loginId);
               },
               child: Text('作成'),
               textColor: Colors.white,
@@ -75,14 +75,14 @@ class _LoginFormState extends State<LoginForm> {
 }
 
 // 初回なので set で保存する
-// void commitToFireStore(String loginId) {
-//   FirebaseFirestore.instance.collection('user_info').doc(UserId.userId).set(
-//     {
-//       'id': UserId.userId,
-//       'loginId': loginId,
-//     },
-//   );
-// }
+void commitToFireStore(String loginId) {
+  FirebaseFirestore.instance.collection('user_info').doc(UserId.userId).set(
+    {
+      'id': UserId.userId,
+      'loginId': loginId,
+    },
+  );
+}
 
 class LoginInfoForm extends StatefulWidget {
   @override


### PR DESCRIPTION
#### 解決issue
https://github.com/shun-shun123/tapiten_app/issues/33
途中です

## 概要
- タイトルの通り

## 実装内容
- Google でサインインしたときに生成される id と、ユーザが設定した loginId の組み合わせを firestore に保存する

## イメージ
- なし
- Firestore の user_info コレクションに保存されることを確認ずみ

## 懸念点
- 8文字以下の validation にひっかかると、ユーザに警告が出る
- しかし、firestore の内部では値が書き換わってしまう
- 今後、検索機能などをつける場合は [#45 ](https://github.com/shun-shun123/tapiten_app/issues/45) を解消すること

