### PR TITLE
初回のモード選択時に isGod フラグを保存

### DIFF
--- a/lib/ui/login/login_page.dart
+++ b/lib/ui/login/login_page.dart
@@ -6,6 +6,7 @@ import 'package:tapiten_app/ui/login/login_view_model.dart';
 import 'package:tapiten_app/storage/user_id.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:tapiten_app/storage/user_login_id.dart';
+import 'package:tapiten_app/ui/select/select_page.dart';
 
 class LoginPage extends StatelessWidget {
   @override
@@ -61,6 +62,9 @@ class _LoginFormState extends State<LoginForm> {
               onPressed: () {
                 _formKey.currentState.validate();
                 commitToFireStore(UserLoginId.loginId);
+                Navigator.push(
+                  context, MaterialPageRoute(builder: (context) => SelectPage())
+                );
               },
               child: Text('作成'),
               textColor: Colors.white,

--- a/lib/ui/select/select_page.dart
+++ b/lib/ui/select/select_page.dart
@@ -57,7 +57,7 @@ class _SelectPageBodyState extends State<SelectPageBody> {
                       IconButton(
                         onPressed:
                             Provider.of<SelectViewModel>(context).selectGodMode,
-                        icon: Image.asset('images/god_circle.png'),
+                        icon: Image.asset('images/god.png'),
                         iconSize: 100.0,
                       ),
                       Text('神さま'),
@@ -68,7 +68,7 @@ class _SelectPageBodyState extends State<SelectPageBody> {
                       IconButton(
                         onPressed: Provider.of<SelectViewModel>(context)
                             .selectSheepMode,
-                        icon: Image.asset('images/sheep_circle.png'),
+                        icon: Image.asset('images/sheep.png'),
                         iconSize: 100.0,
                       ),
                       Text('仔羊'),

--- a/lib/ui/select/select_page.dart
+++ b/lib/ui/select/select_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:tapiten_app/ui/select/select_view_model.dart';
+import 'package:tapiten_app/ui/message/message_page.dart';
+import 'package:tapiten_app/storage/user_mode.dart';
 
 class SelectPage extends StatelessWidget {
   @override
@@ -87,7 +89,14 @@ class _SelectPageBodyState extends State<SelectPageBody> {
                 child: Text(
                   '世界へ行く',
                 ),
-                onPressed: () {},
+                onPressed: () {
+                  print('Current isGod flag is :${UserMode.isGod}');
+                  // TODO: 遷移先の Message ページのエラーが治ったらコメントイン
+                  // Navigator.push(
+                  //   context,
+                  //   MaterialPageRoute(builder: (context) => MessagePage()),
+                  // );
+                },
               ),
             ]),
       ),

--- a/lib/ui/select/select_view_model.dart
+++ b/lib/ui/select/select_view_model.dart
@@ -1,16 +1,19 @@
 import 'package:flutter/material.dart';
+import 'package:tapiten_app/storage/user_mode.dart';
 
 class SelectViewModel extends ChangeNotifier {
   bool _isGod = true;
   bool get isGod => _isGod;
 
   void selectGodMode() {
-    _isGod = true;
+    print('isGod is changed to true');
+    UserMode.isGod = true;
     notifyListeners();
   }
 
   void selectSheepMode() {
-    _isGod = false;
+    print('isGod is changed to false');
+    UserMode.isGod = false;
     notifyListeners();
   }
 }


### PR DESCRIPTION
#### 解決issue
close #33 
これで DONE なはず

## 概要
- isGod のフラグをモード選択時に保存する
- 必要な箇所で適宜 print

## 実装内容
- view_model の中で選択内容によって、isGod を分岐させる
- 見えにくいので、選択時と確定時に print 挟む

## イメージ
![44b0a97b354a0e02309307a40f0dbced](https://user-images.githubusercontent.com/36844012/92560283-1abbca00-f2ad-11ea-8a73-896d0acbcb48.gif)

