### PR TITLE
選択しているモードが丸囲みされるように調整

### DIFF
--- a/lib/ui/select/components/mode_select_button.dart
+++ b/lib/ui/select/components/mode_select_button.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+
+class ModeSelectButton extends StatelessWidget {
+  final Function onPressed;
+  final Image icon;
+  final Color borderColor;
+
+  ModeSelectButton({
+    @required this.onPressed,
+    @required this.icon,
+    @required this.borderColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      child: Container(
+        decoration: BoxDecoration(
+          border: Border.all(color: borderColor, width: 2.0),
+          shape: BoxShape.circle,
+        ),
+        child: IconButton(icon: icon, onPressed: onPressed, iconSize: 100.0),
+      ),
+    );
+  }
+}

--- a/lib/ui/select/select_page.dart
+++ b/lib/ui/select/select_page.dart
@@ -41,7 +41,7 @@ class _SelectPageBodyState extends State<SelectPageBody> {
   void selectMode(int selectedModeIndex) {
     setState(() {
       _selectedModeIndex =
-          _selectedModeIndex != selectedModeIndex ? selectedModeIndex : null;
+          _selectedModeIndex != selectedModeIndex ? selectedModeIndex : 0;
     });
   }
 

--- a/lib/ui/select/select_page.dart
+++ b/lib/ui/select/select_page.dart
@@ -15,7 +15,7 @@ class SelectPage extends StatelessWidget {
       ],
       child: Scaffold(
         // appBar: AppBar(
-        //   title: Text(“Select”),
+        //   title: Text("Select"),
         // ),
         body: SelectPageBody(),
       ),

--- a/lib/ui/select/select_page.dart
+++ b/lib/ui/select/select_page.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:tapiten_app/ui/select/select_view_model.dart';
 import 'package:tapiten_app/ui/message/message_page.dart';
 import 'package:tapiten_app/storage/user_mode.dart';
+import 'package:tapiten_app/ui/select/components/mode_select_button.dart';
 
 class SelectPage extends StatelessWidget {
   @override
@@ -14,7 +15,7 @@ class SelectPage extends StatelessWidget {
       ],
       child: Scaffold(
         // appBar: AppBar(
-        //   title: Text("Select"),
+        //   title: Text(“Select”),
         // ),
         body: SelectPageBody(),
       ),
@@ -28,12 +29,20 @@ class SelectPageBody extends StatefulWidget {
 }
 
 class _SelectPageBodyState extends State<SelectPageBody> {
+  int _selectedModeIndex;
   @override
   void initState() {
     super.initState();
 
     // Listen events by view model.
     //var viewModel = Provider.of<SelectViewModel>(context, listen: false);
+  }
+
+  void selectMode(int selectedModeIndex) {
+    setState(() {
+      _selectedModeIndex =
+          _selectedModeIndex != selectedModeIndex ? selectedModeIndex : null;
+    });
   }
 
   Widget build(BuildContext context) {
@@ -54,22 +63,34 @@ class _SelectPageBodyState extends State<SelectPageBody> {
                 children: <Widget>[
                   Column(
                     children: [
-                      IconButton(
-                        onPressed:
-                            Provider.of<SelectViewModel>(context).selectGodMode,
+                      ModeSelectButton(
+                        onPressed: () {
+                          // MEMO: ここで Prodiver を呼ぶと、警告が出て実行されなかったので直接実行
+                          // MVVM にするためには調査が必要
+                          UserMode.isGod = true;
+                          print('isGod is changed to true');
+                          selectMode(0);
+                        },
                         icon: Image.asset('images/god.png'),
-                        iconSize: 100.0,
+                        borderColor: _selectedModeIndex == 0
+                            ? Colors.black
+                            : Colors.white,
                       ),
                       Text('神さま'),
                     ],
                   ),
                   Column(
                     children: [
-                      IconButton(
-                        onPressed: Provider.of<SelectViewModel>(context)
-                            .selectSheepMode,
+                      ModeSelectButton(
+                        onPressed: () {
+                          UserMode.isGod = false;
+                          print('isGod is changed to false');
+                          selectMode(1);
+                        },
                         icon: Image.asset('images/sheep.png'),
-                        iconSize: 100.0,
+                        borderColor: _selectedModeIndex == 1
+                            ? Colors.black
+                            : Colors.white,
                       ),
                       Text('仔羊'),
                     ],


### PR DESCRIPTION
#### 解決issue
特になし。追加実装に相当

## 概要
- 初回モード選択のときに、選んだ方が黒丸で囲まれるように調整した

## イメージ
![b308758d64b9e0eca33b2f52a7c129ba](https://user-images.githubusercontent.com/36844012/92627300-1ec80600-f306-11ea-9464-c8931c3f243f.gif)

## 懸念点
- MVVM になっていない
