### PR TITLE
メッセージ一覧画面とFirestoreの連携を実装した

### DIFF
--- a/lib/firestore/firestoreManager.dart
+++ b/lib/firestore/firestoreManager.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:tapiten_app/storage/user_id.dart';
 import 'package:tapiten_app/ui/message/model/answer.dart';
 import 'package:tapiten_app/ui/message/model/question.dart';
 
@@ -20,25 +21,21 @@ class FirestoreManager {
     List<Answer> answers = List<Answer>();
     var completer = Completer<List<Answer>>();
 
-    var query = FirebaseFirestore.instance.collection('messages');
+    var query = FirebaseFirestore.instance.collection('messages').doc('answers').collection(UserId.userId);
 
     // collectionのfetchからAnswerリストの作成
     await query.get().then((querySnapshot) async {
       querySnapshot.docs.forEach((element) {
-        // answersの中身を全部イテレーションする
-        element.get('answers').forEach((userEntries) {
-          // userIdでイテレーションする
-          userEntries.forEach((String userId, dynamic answer) {
-            answers.add(Answer(
-              questionerId: answer['questioner_id'],
-              questionContent: answer['question_content'],
-              answer1: answer['answer1'],
-              answer2: answer['answer2'],
-              reviewScore: answer['review_score'],
-              selectedAnswerIndex: answer['selected_answer_index'],
-            ));
-          });
-        });
+        answers.add(
+          Answer(
+            questionerId: element.get('questioner_id'),
+            questionContent: element.get('question_content'),
+            answer1: element.get('answer1'),
+            answer2: element.get('answer2'),
+            reviewScore: element.get('review_score'),
+            selectedAnswerIndex: element.get('selected_answer_index'),
+          ),
+        );
       });
     });
 
@@ -49,25 +46,22 @@ class FirestoreManager {
   Future<List<Question>> fetchQuestionMessagesCollectionAsync() async {
     List<Question> questions = List<Question>();
     var completer = Completer<List<Question>>();
-    var query = FirebaseFirestore.instance.collection('messages');
+    var query = FirebaseFirestore.instance.collection('messages').doc('questions').collection(UserId.userId);
 
-    // collectionのfetchからQuestionリストの作成
-    await query.get().then((querySnapshot) async {
+    var res = query.get();
+    print(res);
+    await res.then((querySnapshot) {
+      print(querySnapshot);
       querySnapshot.docs.forEach((element) {
-        // questionsの中身を全部イテレーションする
-        element.get('questions').forEach((userEntries) {
-          // userIdでイテレーションする
-          userEntries.forEach((String userId, dynamic question) {
-            questions.add(Question(
-              answererId: question['answerer_id'],
-              questionContent: question['question_content'],
-              answer1: question['answer1'],
-              answer2: question['answer2'],
-              godMessage: question['god_message'],
-              selectedAnswerIndex: question['selected_answer_index'],
-            ));
-          });
-        });
+        print('element: $element');
+        questions.add(Question(
+          answer1: element.get('answer1'),
+          answer2: element.get('answer2'),
+          questionContent: element.get('question_content'),
+          godMessage: element.get('god_message'),
+          selectedAnswerIndex: element.get('selected_answer_index'),
+          answererId: element.get('answerer_id'),
+        ));
       });
     });
 

--- a/lib/ui/message/message_list_view.dart
+++ b/lib/ui/message/message_list_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:tapiten_app/storage/user_mode.dart';
 import 'package:tapiten_app/ui/message/message_list_cell.dart';
 import 'package:tapiten_app/ui/message/viewModel/message_list_view_model.dart';
 
@@ -21,7 +22,7 @@ class _MessageListViewState extends State<MessageListView> {
   Widget build(BuildContext context) {
     var cells = <Widget>[];
     var messageList = Provider.of<MessageList>(context);
-    if (isGod) {
+    if (UserMode.isGod) {
       var answers = messageList.answers;
       answers.forEach((answer) {
         cells.add(MessageListCell.god(

--- a/lib/ui/message/message_list_view.dart
+++ b/lib/ui/message/message_list_view.dart
@@ -3,21 +3,14 @@ import 'package:provider/provider.dart';
 import 'package:tapiten_app/storage/user_mode.dart';
 import 'package:tapiten_app/ui/message/message_list_cell.dart';
 import 'package:tapiten_app/ui/message/viewModel/message_list_view_model.dart';
+import 'package:tapiten_app/ui/question/styles/text_style.dart';
 
 class MessageListView extends StatefulWidget {
-  final bool isGod;
-
-  MessageListView({this.isGod});
-
   @override
-  _MessageListViewState createState() => _MessageListViewState(isGod: isGod);
+  _MessageListViewState createState() => _MessageListViewState();
 }
 
 class _MessageListViewState extends State<MessageListView> {
-  final bool isGod;
-
-  _MessageListViewState({this.isGod});
-
   @override
   Widget build(BuildContext context) {
     var cells = <Widget>[];
@@ -39,8 +32,27 @@ class _MessageListViewState extends State<MessageListView> {
     }
     return Container(
       margin: EdgeInsets.only(left: 30, right: 30, top: 10, bottom: 10),
-      child: ListView(
-        children: cells,
+      child: cells.length == 0
+          ? EmptyMessage()
+          : ListView(
+              children: cells,
+            ),
+    );
+  }
+}
+
+class EmptyMessage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: EdgeInsets.only(top: 0),
+      child: Center(
+        child: Text(
+          '迷える仔羊の悩みを解決しましょう',
+          style: kTitleTextStyle.copyWith(
+            color: Colors.black,
+          ),
+        ),
       ),
     );
   }

--- a/lib/ui/message/message_page.dart
+++ b/lib/ui/message/message_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:tapiten_app/storage/user_mode.dart';
 import 'package:tapiten_app/ui/message/message_list_view.dart';
 import 'package:tapiten_app/ui/message/viewModel/message_list_view_model.dart';
 
@@ -10,8 +11,14 @@ class MessagePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    var messageList = MessageList();
+    if (UserMode.isGod) {
+      messageList.fetchMessageListForGod();
+    } else {
+      messageList.fetchMessageListForSheep();
+    }
     return ChangeNotifierProvider(
-      create: (context) => isGod ? MessageList.god([]) : MessageList.sheep([]),
+      create: (context) => messageList,
       child: Scaffold(
         appBar: AppBar(
           title: MessagePageTitle(),

--- a/lib/ui/message/message_page.dart
+++ b/lib/ui/message/message_page.dart
@@ -25,9 +25,7 @@ class MessagePage extends StatelessWidget {
           backgroundColor: Colors.white,
         ),
         body: SafeArea(
-          child: MessageListView(
-            isGod: isGod,
-          ),
+          child: MessageListView(),
         ),
       ),
     );

--- a/lib/ui/message/viewModel/message_list_view_model.dart
+++ b/lib/ui/message/viewModel/message_list_view_model.dart
@@ -13,18 +13,6 @@ class MessageList extends ChangeNotifier {
   List<Question> _questions = [];
   FirestoreManager _firestoreManager = FirestoreManager();
 
-  MessageList() {}
-
-  // 神様用のメッセージ一覧画面コンストラクタ
-  MessageList.god(this._answers) {
-    fetchMessageListForGod();
-  }
-
-  // 子羊のメッセージ一覧画面用コンストラクタ
-  MessageList.sheep(this._questions) {
-    fetchMessageListForSheep();
-  }
-
   // 神様モード用の「メッセージ一覧取得」
   Future<void> fetchMessageListForGod() async {
     _answers = await _firestoreManager.fetchAnswerMessagesCollectionAsync();

--- a/lib/ui/message/viewModel/message_list_view_model.dart
+++ b/lib/ui/message/viewModel/message_list_view_model.dart
@@ -9,9 +9,11 @@ class MessageList extends ChangeNotifier {
   List<Question> get questions => _questions;
 
   // 内部的に値を管理するリストはprivate
-  List<Answer> _answers;
-  List<Question> _questions;
+  List<Answer> _answers = [];
+  List<Question> _questions = [];
   FirestoreManager _firestoreManager = FirestoreManager();
+
+  MessageList() {}
 
   // 神様用のメッセージ一覧画面コンストラクタ
   MessageList.god(this._answers) {
@@ -24,13 +26,13 @@ class MessageList extends ChangeNotifier {
   }
 
   // 神様モード用の「メッセージ一覧取得」
-  void fetchMessageListForGod() async {
+  Future<void> fetchMessageListForGod() async {
     _answers = await _firestoreManager.fetchAnswerMessagesCollectionAsync();
     notifyListeners();
   }
 
   // 子羊モード用の「メッセージ一覧取得」
-  void fetchMessageListForSheep() async {
+  Future<void> fetchMessageListForSheep() async {
     _questions = await _firestoreManager.fetchQuestionMessagesCollectionAsync();
     notifyListeners();
   }


### PR DESCRIPTION
#### 解決issue
close #35 

## 概要
- メッセージ一覧画面でFirestoreから情報を取得するようにしました

## 実装内容
- Firestoreとの接続
- メッセージが空の時に表示するやつも実装

