### PR TITLE
display_id 設定時に firebase に保存する key 名を変更

### DIFF
--- a/lib/ui/login/login_page.dart
+++ b/lib/ui/login/login_page.dart
@@ -80,8 +80,11 @@ class _LoginFormState extends State<LoginForm> {
 void commitToFireStore(String loginId) {
   FirebaseFirestore.instance.collection('user_info').doc(UserId.userId).set(
     {
-      'id': UserId.userId,
-      'loginId': loginId,
+      'display_id': loginId,
+      'god_score': 3,
+      'god_name':'マイペースにお腹が空いた神',
+      'sheep_name':'迷いすぎて困る仔羊',
+      'god_message': '本当の答えは自分の中にあるのではないか'
     },
   );
 }


### PR DESCRIPTION
## 概要
- タイトルの通り

## 実装内容
- このような形で保存する
```
"user_info": 
      id(firebase上でのuid):{
        "display_id": "ユーザーID(英数字8文字以内)"(String),
        "god_score": [0..5](Float), //レビュースコア
        "god_name": "神さまモードの表示名"(String)
        "sheep_name": "仔羊モードの表示名"(String)
        "god_message": "あなたの名言"(String),
      }
```

## イメージ
<img width="829" alt="スクリーンショット 2020-09-10 15 21 48" src="https://user-images.githubusercontent.com/36844012/92689367-da764d80-f379-11ea-9f7f-feddcb2ed814.png">

