### PR TITLE
アピアランスの調整

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -110,10 +110,13 @@ class _MyHomePageState extends State<MyHomePage> {
 
   @override
   Widget build(BuildContext context) {
+    Color primaryColor = UserMode.isGod ? Color(0xffF8D825) : Color(0xff9FD53E);
+    Color backgroundColor = UserMode.isGod ? Colors.white : Color(0xff909090);
+    Color edgeColor = UserMode.isGod ? Color(0xffC7C7CC) : Colors.white;
     return Scaffold(
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       floatingActionButton: FloatingActionButton(
-        backgroundColor: Color(0xffF8D825),
+        backgroundColor: primaryColor,
         onPressed: UserMode.isGod
             ? () {
                 Navigator.of(context).push(
@@ -125,22 +128,22 @@ class _MyHomePageState extends State<MyHomePage> {
                     fullscreenDialog: true,
                   ),
                 );
-              }
+        }
             : () {
-                Navigator.of(context).push(
-                  MaterialPageRoute(
-                    settings: const RouteSettings(name: 'question_sheep'),
-                    builder: (context) {
-                      return QuestionSheepPage();
-                    },
-                    fullscreenDialog: true,
-                  ),
-                );
+          Navigator.of(context).push(
+            MaterialPageRoute(
+              settings: const RouteSettings(name: 'question_sheep'),
+              builder: (context) {
+                return QuestionSheepPage();
               },
+              fullscreenDialog: true,
+            ),
+          );
+        },
         child: Icon(Icons.add),
       ),
       bottomNavigationBar: BottomAppBar(
-        color: Colors.white,
+        color: backgroundColor,
         notchMargin: 6,
         shape: AutomaticNotchedShape(
           RoundedRectangleBorder(),
@@ -160,7 +163,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 child: BottomTabBarItem(
                   Icons.email,
                   'メッセージ',
-                  currentPageIndex == 0 ? Color(0xffF5DB28) : Color(0xff909090),
+                  currentPageIndex == 0 ? primaryColor : edgeColor,
                 ),
               ),
               InkWell(
@@ -169,7 +172,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 child: BottomTabBarItem(
                   Icons.person,
                   'プロフィール',
-                  currentPageIndex == 1 ? Color(0xffF5DB28) : Color(0xff909090),
+                  currentPageIndex == 1 ? primaryColor : edgeColor,
                 ),
               ),
             ],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -114,6 +114,7 @@ class _MyHomePageState extends State<MyHomePage> {
     Color backgroundColor = UserMode.isGod ? Colors.white : Color(0xff909090);
     Color edgeColor = UserMode.isGod ? Color(0xffC7C7CC) : Colors.white;
     return Scaffold(
+      backgroundColor: UserMode.isGod ? Colors.white : Color(0xff909090),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       floatingActionButton: FloatingActionButton(
         backgroundColor: primaryColor,
@@ -128,18 +129,18 @@ class _MyHomePageState extends State<MyHomePage> {
                     fullscreenDialog: true,
                   ),
                 );
-        }
+              }
             : () {
-          Navigator.of(context).push(
-            MaterialPageRoute(
-              settings: const RouteSettings(name: 'question_sheep'),
-              builder: (context) {
-                return QuestionSheepPage();
+                Navigator.of(context).push(
+                  MaterialPageRoute(
+                    settings: const RouteSettings(name: 'question_sheep'),
+                    builder: (context) {
+                      return QuestionSheepPage();
+                    },
+                    fullscreenDialog: true,
+                  ),
+                );
               },
-              fullscreenDialog: true,
-            ),
-          );
-        },
         child: Icon(Icons.add),
       ),
       bottomNavigationBar: BottomAppBar(

--- a/lib/ui/message/message_list_cell.dart
+++ b/lib/ui/message/message_list_cell.dart
@@ -27,10 +27,9 @@ class MessageListCell extends StatelessWidget {
   }
 
   Widget _buildCardForGod(BuildContext context) {
-    return _buildBaseCard(
-      Text(answer.questionContent),
-      Icon(Icons.settings),
-      () {
+    return BuildBaseCard(
+      title: Text(answer.questionContent),
+      onTap: () {
         Navigator.of(context).push(MaterialPageRoute(builder: (context) {
           // メッセージ詳細画面（神様モード）に遷移する
           return MessageDetailPage.god(
@@ -42,10 +41,16 @@ class MessageListCell extends StatelessWidget {
   }
 
   Widget _buildCardForSheep(BuildContext context) {
-    return _buildBaseCard(
-      Text(question.questionContent),
-      Icon(Icons.settings),
-      () {
+    return BuildBaseCard(
+      title: Text(
+        question.questionContent,
+        style: TextStyle(
+          color: Color(0xff909090),
+          fontFamily: 'RictyDiminished-Regular',
+          fontSize: 18,
+        ),
+      ),
+      onTap: () {
         Navigator.of(context).push(MaterialPageRoute(builder: (context) {
           // メッセージ詳細画面（子羊モード）に遷移する
           return MessageDetailPage.sheep(
@@ -55,19 +60,49 @@ class MessageListCell extends StatelessWidget {
       },
     );
   }
+}
 
-  Widget _buildBaseCard(
-    Text title,
-    Icon icon,
-    GestureTapCallback onTap,
-  ) {
+class BuildBaseCard extends StatelessWidget {
+  BuildBaseCard({
+    @required this.title,
+    // @required this.subTitle,
+    // @required this.icon,
+    @required this.onTap,
+  });
+
+  final Text title;
+
+  // final Text subTitle;
+  // final Icon icon;
+  final GestureTapCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
     return Card(
+      margin: EdgeInsets.symmetric(vertical: 8),
+      clipBehavior: Clip.antiAlias,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(20),
+      ),
       color: Color(0xFFE9E9E9),
       child: Container(
-        padding: EdgeInsets.only(top: 10, bottom: 10),
+        padding: EdgeInsets.symmetric(
+          vertical: 8,
+        ),
         child: ListTile(
           title: title,
-          leading: icon,
+          leading: Container(
+            width: 40.0,
+            height: 40.0,
+            decoration: BoxDecoration(
+              color: Colors.white,
+              shape: BoxShape.circle,
+              image: DecorationImage(
+                fit: BoxFit.fill,
+                image: AssetImage("images/sheep.png"),
+              ),
+            ),
+          ),
           onTap: onTap,
         ),
       ),

--- a/lib/ui/message/message_list_cell.dart
+++ b/lib/ui/message/message_list_cell.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:tapiten_app/model/answer.dart';
 import 'package:tapiten_app/model/question.dart';
+import 'package:tapiten_app/storage/user_mode.dart';
 import 'package:tapiten_app/ui/message_detail/message_detail_page.dart';
 
 class MessageListCell extends StatelessWidget {
@@ -95,7 +96,7 @@ class BuildBaseCard extends StatelessWidget {
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(20),
       ),
-      color: Color(0xFFE9E9E9),
+      color: UserMode.isGod ? Color(0xffe8e8e8) : Colors.white,
       child: Container(
         padding: EdgeInsets.symmetric(
           vertical: 8,

--- a/lib/ui/message/message_list_cell.dart
+++ b/lib/ui/message/message_list_cell.dart
@@ -28,7 +28,15 @@ class MessageListCell extends StatelessWidget {
 
   Widget _buildCardForGod(BuildContext context) {
     return BuildBaseCard(
-      title: Text(answer.questionContent),
+      title: Text(
+        answer.questionContent,
+        style: TextStyle(
+          color: Color(0xff909090),
+          fontFamily: 'RictyDiminished-Regular',
+          fontSize: 18,
+        ),
+      ),
+      iconImage: AssetImage("images/sheep.png"),
       onTap: () {
         Navigator.of(context).push(MaterialPageRoute(builder: (context) {
           // メッセージ詳細画面（神様モード）に遷移する
@@ -50,6 +58,7 @@ class MessageListCell extends StatelessWidget {
           fontSize: 18,
         ),
       ),
+      iconImage: AssetImage("images/god.png"),
       onTap: () {
         Navigator.of(context).push(MaterialPageRoute(builder: (context) {
           // メッセージ詳細画面（子羊モード）に遷移する
@@ -65,12 +74,14 @@ class MessageListCell extends StatelessWidget {
 class BuildBaseCard extends StatelessWidget {
   BuildBaseCard({
     @required this.title,
+    @required this.iconImage,
     // @required this.subTitle,
     // @required this.icon,
     @required this.onTap,
   });
 
   final Text title;
+  final AssetImage iconImage;
 
   // final Text subTitle;
   // final Icon icon;
@@ -99,7 +110,7 @@ class BuildBaseCard extends StatelessWidget {
               shape: BoxShape.circle,
               image: DecorationImage(
                 fit: BoxFit.fill,
-                image: AssetImage("images/sheep.png"),
+                image: iconImage,
               ),
             ),
           ),

--- a/lib/ui/message/message_list_view.dart
+++ b/lib/ui/message/message_list_view.dart
@@ -31,6 +31,7 @@ class _MessageListViewState extends State<MessageListView> {
       });
     }
     return Container(
+      color: UserMode.isGod ? Colors.white : Color(0xff909090),
       margin: EdgeInsets.only(left: 30, right: 30, top: 10, bottom: 10),
       child: cells.length == 0
           ? EmptyMessage()
@@ -47,10 +48,19 @@ class EmptyMessage extends StatelessWidget {
     return Container(
       margin: EdgeInsets.only(top: 0),
       child: Center(
-        child: Text(
+        child: UserMode.isGod
+            ? Text(
           '迷える仔羊の悩みを解決しましょう',
           style: kTitleTextStyle.copyWith(
-            color: Colors.black,
+            color: Color(0xff90909090),
+            fontSize: 18,
+          ),
+        )
+            : Text(
+          '迷いを神さまに質問しましょう',
+          style: kTitleTextStyle.copyWith(
+            color: Colors.white,
+            fontSize: 18,
           ),
         ),
       ),

--- a/lib/ui/message/message_page.dart
+++ b/lib/ui/message/message_page.dart
@@ -20,9 +20,10 @@ class MessagePage extends StatelessWidget {
     return ChangeNotifierProvider(
       create: (context) => messageList,
       child: Scaffold(
+        backgroundColor: UserMode.isGod ? Colors.white : Color(0xff909090),
         appBar: AppBar(
           title: MessagePageTitle(),
-          backgroundColor: Colors.white,
+          backgroundColor: UserMode.isGod ? Colors.white : Color(0xff909090),
         ),
         body: SafeArea(
           child: MessageListView(),
@@ -38,7 +39,7 @@ class MessagePageTitle extends StatelessWidget {
     return Text(
       'メッセージ一覧',
       style: TextStyle(
-        color: Colors.grey,
+        color: UserMode.isGod ? Color(0xff909090) : Colors.white,
         fontWeight: FontWeight.bold,
       ),
     );


### PR DESCRIPTION
#### 解決issue
このPRが解決するissueをリンクさせてください
close #64 

## 概要
- メッセージ一覧とボトムバーのアピアランスをモードによって切り替わるようにした

## イメージ
|神さまモード|仔羊モード|
|---|---|
|<img width="320" alt="スクリーンショット 2020-09-11 3 52 17" src="https://user-images.githubusercontent.com/38175830/92786030-df231c00-f3e2-11ea-89d1-4c9321dea3d7.png">|<img width="320" alt="スクリーンショット 2020-09-11 3 52 33" src="https://user-images.githubusercontent.com/38175830/92786076-e77b5700-f3e2-11ea-929c-0e415c83eee3.png">|

## 懸念点
- プロフィール画面でモードを切り替えた後、更新が走らないので他の画面に移動するまではアピアランスが変更されない

## 残タスク
- [ ] 上記懸念点の解消
