### PR TITLE
nullチェック前にuserにアクセスしてしまうとnullReferenceで落ちててそれ以降の処理がいかないっぽい

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -88,12 +88,13 @@ class _MyHomePageState extends State<MyHomePage> {
     try {
       final user = _auth.currentUser;
       print('success check');
-      print('current user: ${user.displayName}');
       if (user == null) {
         Navigator.push(
           context,
           MaterialPageRoute(builder: (context) => SigninWithGoogle()),
         );
+      } else {
+        print('current user: ${user.displayName}');
       }
     } catch (e) {
       print(e);


### PR DESCRIPTION
#### 解決issue
issueにはなかった気がする

## 概要
- アプリ初回起動時のバグFIX

## 実装内容
- log出力にアクセスしてるuserがnullの場合があるので、それの対応

