### PR TITLE
メッセージ詳細画面のレイアウト

### DIFF
--- a/lib/ui/message_detail/message_detail_page.dart
+++ b/lib/ui/message_detail/message_detail_page.dart
@@ -12,33 +12,33 @@ class MessageDetailPage extends StatelessWidget {
   final bool isGod;
   final Answer answer;
   final Question question;
+  final Color bgColor;
 
   // 神様用のコンストラクタ
   MessageDetailPage.god({this.answer})
       : isGod = true,
-        question = null;
+        question = null,
+        bgColor = Color(0xFFF8D825);
 
   // 子羊用のコンストラクタ
   MessageDetailPage.sheep({this.question})
       : isGod = false,
-        answer = null;
+        answer = null,
+        bgColor = Color(0xff9FD53E);
 
   @override
   Widget build(BuildContext context) {
-    return MultiProvider(
-      providers: [],
-      child: Scaffold(
-        appBar: AppBar(
-          backgroundColor: Colors.white,
-          title: MessageDetailPageTitle(),
-          leading: IconButton(
-            icon: Icon(Icons.arrow_back),
-            color: Colors.black,
-            onPressed: () => Navigator.of(context).pop(),
-          ),
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: bgColor,
+        title: MessageDetailPageTitle(),
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back),
+          color: Colors.black,
+          onPressed: () => Navigator.of(context).pop(),
         ),
-        body: _buildBaseBody(isGod ? _buildBodyForGod() : _buildBodyForSheep()),
       ),
+      body: _buildBaseBody(isGod ? _buildBodyForGod() : _buildBodyForSheep()),
     );
   }
 

--- a/lib/ui/message_detail/message_detail_page.dart
+++ b/lib/ui/message_detail/message_detail_page.dart
@@ -18,13 +18,13 @@ class MessageDetailPage extends StatelessWidget {
   MessageDetailPage.god({this.answer})
       : isGod = true,
         question = null,
-        bgColor = Color(0xFFF8D825);
+        bgColor = Color(0xE8E8E8);
 
   // 子羊用のコンストラクタ
   MessageDetailPage.sheep({this.question})
       : isGod = false,
         answer = null,
-        bgColor = Color(0xff9FD53E);
+        bgColor = Color(0xF8F8F8);
 
   @override
   Widget build(BuildContext context) {
@@ -38,7 +38,16 @@ class MessageDetailPage extends StatelessWidget {
           onPressed: () => Navigator.of(context).pop(),
         ),
       ),
-      body: _buildBaseBody(isGod ? _buildBodyForGod() : _buildBodyForSheep()),
+      body: Card(
+        margin:
+            EdgeInsets.only(top: 15.0, bottom: 100.0, left: 15.0, right: 15.0),
+        color: bgColor,
+        shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.all(Radius.circular(10.0))),
+        child: _buildBaseBody(isGod
+            ? _buildBodyForGod(answer.selectedAnswerIndex)
+            : _buildBodyForSheep(question.selectedAnswerIndex)),
+      ),
     );
   }
 
@@ -56,13 +65,14 @@ class MessageDetailPage extends StatelessWidget {
   }
 
   // 神様モードの時のメッセージ詳細画面作成
-  List<Widget> _buildBodyForGod() {
+  List<Widget> _buildBodyForGod(int selectedIndex) {
     return [
       MessageDetailPageIcon(),
       MessageDetailPageQuestionText(content: answer.questionContent),
       TwoAnswerButtons(
         answer1: answer.answer1,
         answer2: answer.answer2,
+        selectIndex: selectedIndex,
       ),
       MessageDetailReview(
         reviewScore: answer.reviewScore,
@@ -71,13 +81,14 @@ class MessageDetailPage extends StatelessWidget {
   }
 
   // 子羊モードの時のメッセージ詳細画面作成
-  List<Widget> _buildBodyForSheep() {
+  List<Widget> _buildBodyForSheep(int selectedIndex) {
     return [
       MessageDetailPageIcon(),
       MessageDetailPageQuestionText(content: question.questionContent),
       TwoAnswerButtons(
         answer1: question.answer1,
         answer2: question.answer2,
+        selectIndex: selectedIndex,
       ),
       MessageDetailRemark(
         remark: question.godMessage,

--- a/lib/ui/message_detail/message_detail_page_icon.dart
+++ b/lib/ui/message_detail/message_detail_page_icon.dart
@@ -1,14 +1,23 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:tapiten_app/storage/user_mode.dart';
 
 class MessageDetailPageIcon extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
+    var userMode = Provider.of<UserMode>(context);
     return Container(
-      padding: EdgeInsets.only(bottom: 20),
-      child: Icon(
-        Icons.settings,
-        color: Colors.black,
-        size: 60,
+      width: 90.0,
+      height: 90.0,
+      decoration: BoxDecoration(
+        color: Colors.white,
+        shape: BoxShape.circle,
+        image: DecorationImage(
+          fit: BoxFit.fill,
+          image: userMode.isGodFlag
+              ? AssetImage("images/sheep.png")
+              : AssetImage("images/god.png"),
+        ),
       ),
     );
   }

--- a/lib/ui/message_detail/message_detail_page_icon.dart
+++ b/lib/ui/message_detail/message_detail_page_icon.dart
@@ -7,6 +7,7 @@ class MessageDetailPageIcon extends StatelessWidget {
   Widget build(BuildContext context) {
     var userMode = Provider.of<UserMode>(context);
     return Container(
+      margin: EdgeInsets.only(top: 40.0),
       width: 90.0,
       height: 90.0,
       decoration: BoxDecoration(

--- a/lib/ui/message_detail/message_detail_page_question_text.dart
+++ b/lib/ui/message_detail/message_detail_page_question_text.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:tapiten_app/storage/user_mode.dart';
 
 class MessageDetailPageQuestionText extends StatelessWidget {
   final String content;
@@ -6,12 +8,19 @@ class MessageDetailPageQuestionText extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Text(
-      content,
-      textAlign: TextAlign.center,
-      style: TextStyle(
-        color: Color(0xFF909090),
-        fontWeight: FontWeight.normal,
+    var userMode = Provider.of<UserMode>(context);
+    var fontColor = userMode.isGodFlag ? Colors.white : Color(0xff909090);
+    return Container(
+      margin: EdgeInsets.only(top: 10.0),
+      width: double.infinity,
+      height: 40.0,
+      child: Text(
+        content,
+        textAlign: TextAlign.center,
+        style: TextStyle(
+          color: fontColor,
+          fontWeight: FontWeight.normal,
+        ),
       ),
     );
   }

--- a/lib/ui/message_detail/message_detail_page_review.dart
+++ b/lib/ui/message_detail/message_detail_page_review.dart
@@ -9,7 +9,7 @@ class MessageDetailReview extends StatelessWidget {
       for (int i = 0; i < 5; i++)
         Icon(
           Icons.star,
-          color: i < reviewScore ? Colors.black : Colors.grey[350],
+          color: i < reviewScore ? Color(0xFF909090) : Color(0XFFFFFFFF),
         )
     ];
     return Container(

--- a/lib/ui/message_detail/message_detail_page_two_answer_buttons.dart
+++ b/lib/ui/message_detail/message_detail_page_two_answer_buttons.dart
@@ -1,12 +1,21 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:tapiten_app/storage/user_mode.dart';
 
 class TwoAnswerButtons extends StatelessWidget {
   final answer1;
   final answer2;
+  final int selectIndex;
 
-  TwoAnswerButtons({this.answer1, this.answer2});
+  TwoAnswerButtons({this.answer1, this.answer2, this.selectIndex});
   @override
   Widget build(BuildContext context) {
+    var userMode = Provider.of<UserMode>(context);
+    var activeColor =
+        userMode.isGodFlag ? Color(0xFFF8DB25) : Color(0xFF9FD53E);
+    var disableColor =
+        userMode.isGodFlag ? Color(0xFFE8E8E8) : Color(0xFFFFFFFF);
+    print(selectIndex);
     return Container(
       margin: EdgeInsets.only(top: 20, bottom: 20),
       child: Center(
@@ -14,14 +23,16 @@ class TwoAnswerButtons extends StatelessWidget {
           children: [
             AnswerButton(
               text: answer1,
-              hasSelected: true,
+              hasSelected: selectIndex == 0,
+              btnColor: selectIndex == 0 ? activeColor : disableColor,
             ),
             SizedBox(
               height: 15,
             ),
             AnswerButton(
               text: answer2,
-              hasSelected: false,
+              hasSelected: selectIndex == 1,
+              btnColor: selectIndex == 1 ? activeColor : disableColor,
             ),
           ],
         ),
@@ -33,21 +44,22 @@ class TwoAnswerButtons extends StatelessWidget {
 class AnswerButton extends StatelessWidget {
   final String text;
   final bool hasSelected;
-  AnswerButton({this.text, this.hasSelected});
+  final Color btnColor;
+  AnswerButton({this.text, this.hasSelected, this.btnColor});
 
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      width: 200,
+      width: hasSelected ? 200 : 100,
       height: 40,
       child: RaisedButton(
         child: Text(text),
-        color: hasSelected ? Color(0xFFF8DB25) : Colors.white,
+        color: btnColor,
         textColor: Color(0xFF909090),
         onPressed: () {},
         shape: RoundedRectangleBorder(
           side: BorderSide(
-            color: Color(0xFFE8E8E8),
+            color: Colors.white,
           ),
           borderRadius: BorderRadius.circular(10),
         ),

--- a/lib/ui/message_detail/message_detail_remark.dart
+++ b/lib/ui/message_detail/message_detail_remark.dart
@@ -11,15 +11,19 @@ class MessageDetailRemark extends StatelessWidget {
         children: [
           Text('今回の神様からの名言'),
           SizedBox(
-            width: 200,
+            width: 250,
             height: 100,
-            child: Container(
+            child: Card(
               color: Color(0xFF909090),
-              child: Text(
-                remark,
-                textAlign: TextAlign.center,
-                style: TextStyle(
-                  color: Colors.white,
+              shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.all(Radius.circular(10.0))),
+              child: Center(
+                child: Text(
+                  remark,
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    color: Colors.white,
+                  ),
                 ),
               ),
             ),


### PR DESCRIPTION
#### 解決issue
close #65 

## 概要
- メッセージ詳細画面の実装をしました

## 実装内容
- message_detail_page.dartの主な修正

## イメージ
<img width="515" alt="スクリーンショット 2020-09-11 14 33 00" src="https://user-images.githubusercontent.com/29162559/92867746-ed515680-f43b-11ea-9bd9-6154435b4940.png">
<img width="559" alt="スクリーンショット 2020-09-11 14 33 08" src="https://user-images.githubusercontent.com/29162559/92867753-ef1b1a00-f43b-11ea-820c-24a348a816fe.png">


## 懸念点
ColorCodeとか所々違うか所々違うかもしれない

## 残タスク
- [ ] XDとの細かな部分の照らし合わせ
