### PR TITLE
未ログイン時のルートを変更

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,7 @@ import 'package:tapiten_app/ui/question/finish/finish_sheep_page.dart';
 import 'package:tapiten_app/ui/question/matching/matching_sheep_page.dart';
 import 'package:tapiten_app/ui/question/question/question_sheep_page.dart';
 import 'package:tapiten_app/ui/tabbar/bottom_tabbar_item.dart';
+import 'package:tapiten_app/ui/top/top_page.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -95,7 +96,7 @@ class _MyHomePageState extends State<MyHomePage> {
       if (user == null) {
         Navigator.push(
           context,
-          MaterialPageRoute(builder: (context) => SigninWithGoogle()),
+          MaterialPageRoute(builder: (context) => TopPage()),
         );
       } else {
         print('current user: ${user.displayName}');


### PR DESCRIPTION
## 概要
- タイトルの通り

## 実装内容
- Google SignIn ボタンが配置している Top のウィジェットを返すようにした
- 画像を参照

## イメージ

|Before|After|
|---|---|
|
![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-09-11 at 14 42 00](https://user-images.githubusercontent.com/36844012/92869583-ecb9bf80-f43d-11ea-87a8-f0b37c1e181f.png)
|
![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-09-11 at 14 44 40](https://user-images.githubusercontent.com/36844012/92869607-f3483700-f43d-11ea-9f9a-91a59f3650ef.png)
|

