### PR TITLE
プロフ編集から戻った時の挙動を修正

### DIFF
--- a/lib/ui/profile/profile_message.dart
+++ b/lib/ui/profile/profile_message.dart
@@ -33,6 +33,7 @@ class _ProfileMessageState extends State<ProfileMessage> {
             ),
             Text(
               messageText,
+              textAlign: TextAlign.center,
               style: kTitleTextStyle.copyWith(
                 fontSize: 20,
                 color: Color(0xFF909090),

--- a/lib/ui/profile/profile_page.dart
+++ b/lib/ui/profile/profile_page.dart
@@ -29,6 +29,7 @@ class _ProfilePageState extends State<ProfilePage> {
     print('rebuild ProfilePage');
 
     var profileEditviewModel = new ProfileEditViewModel();
+
     return MultiProvider(
       providers: [
         ChangeNotifierProvider(create: (_) => ProfileUserMode()),

--- a/lib/ui/profile/profile_page.dart
+++ b/lib/ui/profile/profile_page.dart
@@ -28,10 +28,11 @@ class _ProfilePageState extends State<ProfilePage> {
   Widget build(BuildContext context) {
     print('rebuild ProfilePage');
 
+    var profileEditviewModel = new ProfileEditViewModel();
     return MultiProvider(
       providers: [
         ChangeNotifierProvider(create: (_) => ProfileUserMode()),
-        ChangeNotifierProvider(create: (_) => ProfileEditViewModel()),
+        ChangeNotifierProvider.value(value: profileEditviewModel),
       ],
       child: Scaffold(
         backgroundColor: (UserMode.isGod) ? Colors.white : Color(0xFF909090),
@@ -44,15 +45,28 @@ class _ProfilePageState extends State<ProfilePage> {
                 Icons.edit,
                 color: (UserMode.isGod) ? Color(0xFF909090) : Colors.white,
               ),
-              onPressed: () => {
-                Navigator.of(context).push(SlidePageRoute(
-                  child: ProfileEditPage(
-                    initGodName: godName,
-                    initSheepName: sheepName,
-                    initDisplayId: displayId,
-                    initMessage: message,
+              onPressed: () async {
+                bool result = await Navigator.of(context).push(
+                  // SlidePageRoute(
+                  //   child: ProfileEditPage(
+                  //     initGodName: godName,
+                  //     initSheepName: sheepName,
+                  //     initDisplayId: displayId,
+                  //     initMessage: message,
+                  //   ),
+                  // ),
+                  MaterialPageRoute(
+                    builder: (context) => new ProfileEditPage(
+                      initGodName: godName,
+                      initSheepName: sheepName,
+                      initDisplayId: displayId,
+                      initMessage: message,
+                    ),
                   ),
-                ))
+                );
+                if (result) {
+                  profileEditviewModel.getProfile();
+                }
               },
             ),
           ],

--- a/lib/ui/profile_edit/profile_edit_page.dart
+++ b/lib/ui/profile_edit/profile_edit_page.dart
@@ -7,6 +7,7 @@ import 'package:tapiten_app/ui/profile_edit/profile_edit_info.dart';
 import 'package:tapiten_app/ui/profile_edit/profile_edit_view_model.dart';
 import 'package:tapiten_app/ui/question/styles/text_style.dart';
 
+import '../../main.dart';
 import '../../slide_page_route.dart';
 
 class ProfileEditPage extends StatelessWidget {
@@ -41,7 +42,7 @@ class ProfileEditPage extends StatelessWidget {
               color: (UserMode.isGod) ? Color(0xFF909090) : Colors.white,
             ),
             onPressed: () => {
-              Navigator.of(context).pop(),
+              Navigator.of(context).pop(false),
             },
           ),
           actions: [
@@ -50,11 +51,13 @@ class ProfileEditPage extends StatelessWidget {
                 Icons.check,
                 color: (UserMode.isGod) ? Color(0xFF909090) : Colors.white,
               ),
-              onPressed: () => {
-                profileEditViewModel.saveProfile(),
-                Navigator.of(context).pushReplacement(SlidePageRoute(
-                  child: ProfilePage(),
-                ))
+              onPressed: () {
+                profileEditViewModel.saveProfile();
+                // Navigator.of(context).pushReplacement(SlidePageRoute(
+                //   child: MyHomePage(),
+                // ))
+                Navigator.pop(context, true);
+                //return Future.value(false);
               },
             ),
           ],

--- a/lib/ui/profile_edit/profile_edit_page.dart
+++ b/lib/ui/profile_edit/profile_edit_page.dart
@@ -53,11 +53,7 @@ class ProfileEditPage extends StatelessWidget {
               ),
               onPressed: () {
                 profileEditViewModel.saveProfile();
-                // Navigator.of(context).pushReplacement(SlidePageRoute(
-                //   child: MyHomePage(),
-                // ))
                 Navigator.pop(context, true);
-                //return Future.value(false);
               },
             ),
           ],


### PR DESCRIPTION
## 概要
- プロフィール編集画面→プロフィール画面に移動したときに、データをロードし直す処理を入れた

## 実装内容
- プロフ編集→プロフ画面の画面遷移はpopで行い、プロフ画面にtrue/falseを返す
- 編集完了ボタンを押した時はtrueを返す
- プロフ画面では、trueが帰った場合、データをロードして、viewに反映する

## 懸念点
- プロフ画面→プロフ編集画面の遷移をSlidePageRouteではなく、MaterialPageRouteを使った
- SlidePageRouteでは値を返すことができなかったから

