### PR TITLE
メッセージ画面までの導通

### DIFF
--- a/lib/ui/login/sign_in_with_google.dart
+++ b/lib/ui/login/sign_in_with_google.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:tapiten_app/main.dart';
 import 'package:tapiten_app/storage/user_id.dart';
+import 'package:tapiten_app/ui/login/login_page.dart';
 
 class SignInWithGoogleButton extends StatelessWidget {
   @override
@@ -57,7 +58,7 @@ class _SigninWithGoogleState extends State<SigninWithGoogle> {
     if (user == null) return;
     // TODO: リダイレクト先の入力項目は要調整
     Navigator.push(
-        context, MaterialPageRoute(builder: (context) => MyHomePage()));
+        context, MaterialPageRoute(builder: (context) => LoginPage()));
   }
 
   // ボタン

--- a/lib/ui/select/select_page.dart
+++ b/lib/ui/select/select_page.dart
@@ -4,6 +4,7 @@ import 'package:tapiten_app/ui/select/select_view_model.dart';
 import 'package:tapiten_app/ui/message/message_page.dart';
 import 'package:tapiten_app/storage/user_mode.dart';
 import 'package:tapiten_app/ui/select/components/mode_select_button.dart';
+import 'package:tapiten_app/main.dart';
 
 class SelectPage extends StatelessWidget {
   @override
@@ -113,10 +114,10 @@ class _SelectPageBodyState extends State<SelectPageBody> {
                 onPressed: () {
                   print('Current isGod flag is :${UserMode.isGod}');
                   // TODO: 遷移先の Message ページのエラーが治ったらコメントイン
-                  // Navigator.push(
-                  //   context,
-                  //   MaterialPageRoute(builder: (context) => MessagePage()),
-                  // );
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (context) => MyHomePage()),
+                  );
                 },
               ),
             ]),


### PR DESCRIPTION
## 概要
- ログイン〜メッセージ画面までのルーティング修正

## 実装内容
- 動作には条件があり添付の issue を参照
- googleログイン→ID設定画面→モード選択→メッセージ一覧という流れ

## 関連 issue
close [#84 ](https://github.com/shun-shun123/tapiten_app/issues/84)