### PR TITLE
モード選択ページからホーム画面に遷移する際、pushAndRemoveUntilを使ってそれまでの画面を全て破棄する: 戻れない遷移にした

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -73,7 +73,6 @@ class MyApp extends StatelessWidget {
           '/matching_sheep': (context) => MatchingSheepPage(),
           '/finish_sheep': (context) => FinishSheepPage(),
         },
-        // home: MyHomePage(),
       ),
     );
   }

--- a/lib/ui/select/select_page.dart
+++ b/lib/ui/select/select_page.dart
@@ -1,10 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:tapiten_app/ui/select/select_view_model.dart';
-import 'package:tapiten_app/ui/message/message_page.dart';
+import 'package:tapiten_app/main.dart';
 import 'package:tapiten_app/storage/user_mode.dart';
 import 'package:tapiten_app/ui/select/components/mode_select_button.dart';
-import 'package:tapiten_app/main.dart';
+import 'package:tapiten_app/ui/select/select_view_model.dart';
 
 class SelectPage extends StatelessWidget {
   @override
@@ -113,10 +112,11 @@ class _SelectPageBodyState extends State<SelectPageBody> {
                 ),
                 onPressed: () {
                   print('Current isGod flag is :${UserMode.isGod}');
-                  // TODO: 遷移先の Message ページのエラーが治ったらコメントイン
-                  Navigator.push(
+
+                  Navigator.pushAndRemoveUntil(
                     context,
                     MaterialPageRoute(builder: (context) => MyHomePage()),
+                    (_) => false,
                   );
                 },
               ),


### PR DESCRIPTION
## 概要
- モード選択画面からの画面遷移において、以前の画面に戻れてしまう状態だったのを修正した。